### PR TITLE
Use PAT to add pr-pull label after tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,3 +41,14 @@ jobs:
         with:
           name: bottles
           path: '*.bottle.*'
+  
+  # After the matrix job above, add the "pr-pull" label to commence with auto-merging.
+  label:
+    name: Add pr-pull label
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Add label
+        env:
+          GITHUB_TOKEN: ${{ secrets.LABEL_TOKEN }}
+        run: |
+          gh pr edit --add-label "pr-pull" "${{ github.event.number }}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,9 +44,13 @@ jobs:
   
   # After the matrix job above, add the "pr-pull" label to commence with auto-merging.
   label:
-    name: Add pr-pull label
+    name: pr-pull label
+    needs: test-bot
     runs-on: ubuntu-20.04
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        
       - name: Add label
         env:
           GITHUB_TOKEN: ${{ secrets.LABEL_TOKEN }}


### PR DESCRIPTION
This change-set uses a personal access token to add the `pr-pull` to any pull-request that passes the test-bot.